### PR TITLE
Add TezTools.io

### DIFF
--- a/src/utils/html.js
+++ b/src/utils/html.js
@@ -158,7 +158,8 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://cloudflare-ipfs.com/
       https://ipfs.io/
       https://templewallet.com/logo.png
-      https://gateway.pinata.cloud/;
+      https://gateway.pinata.cloud/
+      https://*.teztools.io;
     font-src
       'self'
       data:
@@ -167,7 +168,8 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://cloudflare-ipfs.com/
       https://fonts.googleapis.com/
       https://ipfs.io/
-      https://gateway.pinata.cloud/;
+      https://gateway.pinata.cloud/
+      https://*.teztools.io;
     connect-src
       'self'
       https://better-call.dev
@@ -194,7 +196,8 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://*.coinmarketcap.com
       https://api.openweathermap.org
       https://hicetnunc.xyz
-      https://*.hicetnunc.xyz;
+      https://*.hicetnunc.xyz
+      https://*.teztools.io;
     manifest-src
       'self';
     base-uri
@@ -210,7 +213,8 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://*.infura-ipfs.io
       https://cloudflare-ipfs.com/
       https://ipfs.io/
-      https://gateway.pinata.cloud/;
+      https://gateway.pinata.cloud/
+      https://*.teztools.io;
     prefetch-src
       'self'
       https://ipfs.infura.io
@@ -218,7 +222,8 @@ export function injectCSPMetaTagIntoHTML(html) {
       https://cloudflare-ipfs.com/
       https://fonts.googleapis.com/
       https://ipfs.io/
-      https://gateway.pinata.cloud/;
+      https://gateway.pinata.cloud/
+      https://*.teztools.io;
     worker-src
       'self'
       'unsafe-inline'


### PR DESCRIPTION
Add teztools.io domains to supported providers list.

Let me know if there are any other places I need to add to. Teztools currently provides data, as well as additional media support for broken IPFS links provided by creators. down the line we will be adding additional media and special support for NFTs. 