### PR TITLE
Fix banned account swaps

### DIFF
--- a/src/pages/objkt-display/index.js
+++ b/src/pages/objkt-display/index.js
@@ -165,6 +165,8 @@ export const ObjktDisplay = () => {
     } else {
       objkt.ban = await getRestrictedAddresses()
       objkt.restricted = false
+      // filter swaps from banned account
+      if (objkt.swaps && objkt.ban) objkt.swaps = objkt.swaps.filter(s => (s.status > 0 || !objkt.ban.includes(s.creator_id)))
       setNFT(objkt)
     }
     setLoading(false)


### PR DESCRIPTION
When a swap is from a banned wallet, the collect button is currently removed in the swap list of an objkt, so no-one can collect from the banned account. But if the banned wallet is the first swap, then the swap is still available through the main collect button.

This fix totally remove swaps from banned account, including on the main collect button