### PR TITLE
fix: 🐛 Shuffle on refresh instead of daily

### DIFF
--- a/src/components/header/styles.module.scss
+++ b/src/components/header/styles.module.scss
@@ -46,7 +46,7 @@
 
       img {
         width: auto;
-        height: 37px;
+        height: 32px;
       }
     }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,7 @@ export const getBanBlockList = () => banBlockList
 
 let logoList = []
 export const setLogoList = (data) => {
+  // Shuffles the list daily
   let logos = data.logos;
   let currentIndex = logos.length, temporaryValue, randomIndex;
   const date = new Date(Date.now());

--- a/src/context/HicetnuncContext.js
+++ b/src/context/HicetnuncContext.js
@@ -270,7 +270,7 @@ class HicetnuncContextProviderClass extends Component {
       logo: '',
       setLogo: () => {
         const logo_list = getLogoList()
-        this.setState({ logo: logo_list[0] })
+        this.setState({ logo: logo_list[Math.floor(Math.random() * logo_list.length)] })
       },
       // theme, DO NO CHANGE!
       theme: 'light',


### PR DESCRIPTION
Also scale the logo to 32px to match @denscimonk guidelines.
I also kept the daily shuffle code around if needed later on.