### PR TITLE
Webkit logo fix

### DIFF
--- a/src/components/header/styles.module.scss
+++ b/src/components/header/styles.module.scss
@@ -34,12 +34,10 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      height: 22.5px;
       color: var(--text-color);
       font-size: 22px;
 
       svg {
-        height: 22.5px;
         // fill: var(--text-color);
         transition: fill #{$theme-duration} ease-out;
       }


### PR DESCRIPTION
This should fix the issue where logos are cut off on webkit-based browsers.

Before:
![after](https://user-images.githubusercontent.com/83504509/152086823-f469efe9-3582-4145-b97e-c1c5a1abb0e2.png)

After:
![After](https://media.discordapp.net/attachments/908710947412140082/938258072554586114/Screen_Shot_2022-02-01_at_9.22.04_PM.png?width=749&height=468)