### PR TITLE
fix: ⚡️ Absolute path for mirrors and update branding

### DIFF
--- a/public/languages/de.json
+++ b/public/languages/de.json
@@ -33,7 +33,7 @@
     "collection": "Sammlung"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "Diese dezentralisierte Anwendung ermöglicht den Nutzern, dezentralisierte digitale Objekte zu verwalten. Alle Transaktionen werden mittels öffentlicher smart contracts auf der Tezos Blockchain durchgeführt.",
       "IPFS OBJKTs können ohne Genehmigung geminted und gehandelt werden. Dieses Webseite wurde als Experiment entwickelt um die Möglichkeiten neuer Crypto-Ökonomien zu erforschen.",

--- a/public/languages/de.json
+++ b/public/languages/de.json
@@ -6,7 +6,7 @@
       { "primary": "random", "route": "/random" },
       { "primary": "OBJKTs", "route": "/mint" },
       { "primary": "Sammlung verwalten", "route": "/sync" },
-      { "primary": "Über hicetnunc", "route": "/about" }
+      { "primary": "Über teia", "route": "/about" }
     ]
   },
   "footer": {
@@ -66,7 +66,7 @@
       "amount": "OBJKT Anzahl",
       "price": "Preis pro OBJKT (in tez)",
       "cta": "swap it",
-      "warning": "Bei swaps mit einem Wert > 0 behält hicetnunc 2.5% Gebühren zum Betrieb der Plattform ein."
+      "warning": "Bei swaps mit einem Wert > 0 behält teia 2.5% Gebühren zum Betrieb der Plattform ein."
     },
     "cancel": {
       "title": "Du bist im Begriff, den swap abzubrechen",

--- a/public/languages/en.json
+++ b/public/languages/en.json
@@ -10,7 +10,7 @@
     ]
   },
   "footer": {
-    "mint": "This is an experimental dApp, provided by the HEN Community for the HEN Community. It is a fork of the original Hic et Nunc created by Rafael Lima. Use it at your own risk.",
+    "mint": "This is an experimental dApp, provided by the Teia Community for the Teia Community. It is a fork of the original Hic et Nunc created by Rafael Lima. Use it at your own risk.",
     "warning": "use it consciously. visit artists profiles. be careful with copy minters."
   },
   "home": {
@@ -35,7 +35,7 @@
     "collabs": "collabs"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "The present decentralized application allows its users to manage decentralized digital assets, serving as a public smart contract infrastructure on Tezos Blockchain.",
       "IPFS OBJKTs can be minted and traded by permissionless means. such experiment was designed intending to imagine alternative crypto economies.",

--- a/public/languages/fr.json
+++ b/public/languages/fr.json
@@ -34,7 +34,7 @@
     "collection": "collection"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "Cette application décentralisée permet à ses utilisateurs de gérer des biens digitaux décentralisés, comme infrastructure publique de contrats intelligents sur la Blockchain Tezos.",
       "Les OBJKTs IPFS peuvent être émis et échangés de façon libre. L'ambition de cet outil est d'imaginer des économies crypto alternatives.",

--- a/public/languages/it.json
+++ b/public/languages/it.json
@@ -34,7 +34,7 @@
     "collection": "collezione"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "Questa applicazione decentralizzata consente ai propri utenti di gestire risorse digitali, fungendo come infrastruttura disponibile al pubblico per interagire con smart contract sviluppati sulla Tezos blockchain.",
       "Gli OBJKT su IPFS possono essere creati e scambiati tramite il protocollo senza intermediari. Questo esperimento è stato sviluppato con l'idea di crypto economie alternative in mente.",

--- a/public/languages/ja.json
+++ b/public/languages/ja.json
@@ -9,7 +9,7 @@
         "route": "/mint"
       },
       { "primary": "作品管理", "route": "/sync" },
-      { "primary": "hic et nunc について", "route": "/about" }
+      { "primary": "teia について", "route": "/about" }
     ]
   },
   "footer": {
@@ -36,7 +36,7 @@
     "collection": "コレクション"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "この分散型アプリケーションは、テゾスブロックチェーン上で稼働する分散型デジタル資産を管理するための公開スマートコントラクトインフラストラクチャです。",
       "IPFS OBJKT資産は、パーミッションレスにミント(生成)や取引ができます。 この実験は、暗号技術を応用した経済のオルタナティブを模索することを意図して設計されました。",

--- a/public/languages/pt.json
+++ b/public/languages/pt.json
@@ -34,7 +34,7 @@
     "collection": "coleção"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "The present decentralized application allows its users to manage decentralized digital assets, serving as a public smart contract infrastructure on Tezos Blockchain.",
       "IPFS OBJKTs can be minted and traded by permissionless means. such experiment was designed intending to imagine alternative crypto economies.",

--- a/public/languages/zh-tw.json
+++ b/public/languages/zh-tw.json
@@ -6,7 +6,7 @@
       { "primary": "random", "route": "/random" },
       { "primary": "OBJKTs", "route": "/mint" },
       { "primary": "作品管理", "route": "/sync" },
-      { "primary": "關於hic et nunc", "route": "/about" }
+      { "primary": "關於teia", "route": "/about" }
     ]
   },
   "footer": {
@@ -34,7 +34,7 @@
     "collection": "藝術收集"
   },
   "about": {
-    "title": "hic et nunc",
+    "title": "teia",
     "paragraphs": [
       "目前的去中心化應用程序允許其用戶管理去中心化數位資產，作為Tezos區塊鏈上的公共智能合約基礎設施。",
       "IPFS OBJKTs 這種實驗的設計意圖是想像另一種加密經濟。",

--- a/src/components/header/index.js
+++ b/src/components/header/index.js
@@ -72,7 +72,7 @@ export const Header = () => {
             <div className={styles.logo}>
               {/* HIC LOGO */}
               {true && (
-                <img src={`/logos/${context.theme}/${context.logo}`} alt="teia"></img>
+                <img src={`https://teia.art/logos/${context.theme}/${context.logo}`} alt="teia"></img>
               )}
               {/* PRIDE LOGO */}
               {false && <img src="/hen-pride.gif" alt="pride 2021" />}

--- a/src/components/layout/page/index.js
+++ b/src/components/layout/page/index.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import { VisuallyHidden } from '../../visually-hidden'
 import styles from './styles.module.scss'
 
-export const Page = ({ title = 'teia', children = null, large }) => {
+export const Page = ({ title = '', children = null, large }) => {
   const classes = classnames({
     [styles.container]: true,
     [styles.large]: large,

--- a/src/components/layout/page/index.js
+++ b/src/components/layout/page/index.js
@@ -4,7 +4,7 @@ import classnames from 'classnames'
 import { VisuallyHidden } from '../../visually-hidden'
 import styles from './styles.module.scss'
 
-export const Page = ({ title = 'hic et nunc', children = null, large }) => {
+export const Page = ({ title = 'teia', children = null, large }) => {
   const classes = classnames({
     [styles.container]: true,
     [styles.large]: large,
@@ -13,9 +13,9 @@ export const Page = ({ title = 'hic et nunc', children = null, large }) => {
     <main className={classes}>
       <Helmet>
         {title !== '' ? (
-          <title>{title} - hic et nunc</title>
+          <title>{title} - teia</title>
         ) : (
-          <title>hic et nunc</title>
+          <title>teia</title>
         )}
       </Helmet>
       <VisuallyHidden as="h1">{title}</VisuallyHidden>

--- a/src/components/media-types/vector/index.js
+++ b/src/components/media-types/vector/index.js
@@ -49,7 +49,7 @@ export const VectorComponent = ({
     return (
       <div className={classes}>
         <iframe
-          title="hic et nunc SVG renderer"
+          title="teia SVG renderer"
           src={path}
           sandbox="allow-scripts"
           scrolling="no"
@@ -61,7 +61,7 @@ export const VectorComponent = ({
       <div className={styles.container + ' vector-container'}>
         <iframe
           className={styles.vector + ' vector'}
-          title="hic et nunc SVG renderer"
+          title="teia SVG renderer"
           src={path}
           sandbox="allow-scripts"
           scrolling="no"

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -110,7 +110,7 @@ export class About extends Component {
           </Padding>
         </Container>
 {/*         <BottomBanner>
-        Collecting has been temporarily disabled. Follow <a href="https://twitter.com/hen_community" target="_blank">@hicetnunc_art</a> or <a href="https://discord.gg/7pZrPCcgnG" target="_blank">join the discord</a> for updates.
+        Collecting has been temporarily disabled. Follow <a href="https://twitter.com/TeiaCommunity" target="_blank">@hicetnunc_art</a> or <a href="https://discord.gg/7pZrPCcgnG" target="_blank">join the discord</a> for updates.
         </BottomBanner> */}
       </Page>
     )

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -26,7 +26,7 @@ export class About extends Component {
       <Page title="about" large>
         <Container>
           <Padding>
-            <strong>hic et nunc</strong>
+            <strong>teia</strong>
           </Padding>
         </Container>
 
@@ -51,7 +51,7 @@ export class About extends Component {
         <Container>
           <Padding>
             <div className={styles.buttons}>
-              <p>Join or contact hic et nunc on</p>
+              <p>Join or contact teia on</p>
               &nbsp;
               <Button href="https://discord.gg/7pZrPCcgnG">
                 <Primary>
@@ -59,7 +59,7 @@ export class About extends Component {
                 </Primary>
               </Button>
               <p>,</p>&nbsp;
-              <Button href="https://twitter.com/hen_community">
+              <Button href="https://twitter.com/TeiaCommunity">
                 <Primary>
                   <strong>twitter</strong>
                 </Primary>


### PR DESCRIPTION
- Uses absolute path for logos:
  As raised by @Pixel10312 over the discord, mirrors could not
access the logos.
- renames hic et nunc in `translations` and remaining `page titles`
- replaces the twitter handle with the new official one